### PR TITLE
Switch site colors to orange/red theme

### DIFF
--- a/app/admin/dashboard/add-item/page.tsx
+++ b/app/admin/dashboard/add-item/page.tsx
@@ -386,7 +386,7 @@ if (selectedSubSubcategory && selectedSubSubcategory !== '__new__') {
 
       <button
         type="submit"
-        className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700"
+        className="w-full bg-primary text-white p-2 rounded hover:bg-accent"
       >
         Add Item
       </button>

--- a/app/admin/dashboard/categories/page.tsx
+++ b/app/admin/dashboard/categories/page.tsx
@@ -28,7 +28,7 @@ export default function CategoriesPage() {
             <div className="flex justify-between items-center">
               <span>{cat.name || 'Unnamed Category'}</span>
               <a
-                className="text-blue-600"
+                className="text-accent"
                 href={`/admin/dashboard/categories/${cat.id}/subcategories`}
               >
                 View Subcategories →

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -28,7 +28,7 @@ export default function CategoriesPage() {
             <div className="flex justify-between items-center">
               <span>{cat.name}</span>
               <a
-                className="text-blue-600"
+                className="text-accent"
                 href={`/admin/dashboard/categories/${cat.id}/subcategories`}
               >
                 View Subcategories →

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -73,7 +73,7 @@ export default function AdminLoginPage() {
 
         <button
           type="submit"
-          className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700 transition"
+          className="w-full bg-primary text-white p-2 rounded hover:bg-accent transition"
         >
           Login
         </button>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -1,10 +1,10 @@
 export default function Hero() {
   return (
-    <section className="relative bg-gradient-to-br from-purple-700 to-pink-400 text-white px-8 py-20 flex items-center justify-between h-screen">
+    <section className="relative bg-gradient-to-br from-primary to-accent text-white px-8 py-20 flex items-center justify-between h-screen">
       <div className="max-w-xl">
         <h1 className="text-4xl font-bold leading-snug">
           Synego – PVC-producten met een <br />
-          <span className="text-blue-300">uitzonderlijke afwerkingskwaliteit</span>
+          <span className="text-accent">uitzonderlijke afwerkingskwaliteit</span>
         </h1>
       </div>
     </section>

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -35,7 +35,7 @@ export default function Navbar() {
   const cachedCategories = useMemo(() => categories, [categories]);
 
   return (
-    <nav className="bg-white shadow border-b text-gray-800 font-roboto text-[16px] z-50 relative">
+    <nav className="bg-primary text-white shadow border-b font-roboto text-[16px] z-50 relative">
       <div className="max-w-screen-xl mx-auto flex items-center justify-between px-6 py-4 relative z-50">
         {/* Logo */}
         <img src="/logo.png" alt="Logo" className="h-10" />
@@ -43,7 +43,7 @@ export default function Navbar() {
         {/* Nav Links */}
         <ul className="flex gap-8 items-center font-medium relative">
           <li>
-            <Link href="#" className="hover:text-blue-600 transition">
+            <Link href="#" className="hover:text-accent transition">
               Over het bedrijf
             </Link>
           </li>
@@ -58,7 +58,7 @@ export default function Navbar() {
   <div className="inline-block px-4 py-2">
     <Link
       href="/products"
-      className="hover:text-blue-600 transition cursor-pointer"
+      className="hover:text-accent transition cursor-pointer"
       onClick={(e) => {
         // Optional: close dropdown when navigating
         setShowDropdown(false);
@@ -75,7 +75,7 @@ export default function Navbar() {
                 {cachedCategories.map((cat) => (
                   <div
                     key={cat.id}
-                    className="relative group flex flex-col items-center w-32 text-center hover:text-blue-600 transition"
+                    className="relative group flex flex-col items-center w-32 text-center hover:text-accent transition"
                   >
                     <span className="font-semibold cursor-default">{cat.name}</span>
 
@@ -84,7 +84,7 @@ export default function Navbar() {
                         {cat.subcategories.map((sub) => (
                           <li
                             key={sub.id}
-                            className="hover:text-blue-600 cursor-pointer px-3 py-1 whitespace-nowrap"
+                            className="hover:text-accent cursor-pointer px-3 py-1 whitespace-nowrap"
                           >
                             {sub.name}
                           </li>
@@ -98,13 +98,13 @@ export default function Navbar() {
           </div>
 
           <li>
-            <Link href="#" className="hover:text-blue-600 transition">
+            <Link href="#" className="hover:text-accent transition">
               Over Ons
             </Link>
           </li>
 
           <li>
-            <Link href="#" className="hover:text-blue-600 transition">
+            <Link href="#" className="hover:text-accent transition">
               Contact
             </Link>
           </li>

--- a/app/products/[category]/[subcategoryId]/[subsubcategory]/items/[itemId]/page.tsx
+++ b/app/products/[category]/[subcategoryId]/[subsubcategory]/items/[itemId]/page.tsx
@@ -77,7 +77,7 @@ export default function ItemDetailPage() {
             <ul className="space-y-4 text-lg">
               {item.bulletpoints?.map((point: string, i: number) => (
                 <li key={i} className="flex items-start gap-2">
-                  <span className="text-blue-600">✓</span>
+                  <span className="text-accent">✓</span>
                   <span>{point}</span>
                 </li>
               ))}

--- a/app/products/[category]/[subcategoryId]/items/[itemId]/page.tsx
+++ b/app/products/[category]/[subcategoryId]/items/[itemId]/page.tsx
@@ -67,7 +67,7 @@ export default function ItemDetailPage() {
             <ul className="space-y-3 text-lg">
               {item.bulletpoints?.map((point: string, i: number) => (
                 <li key={i} className="flex items-start gap-3">
-                  <span className="text-blue-600 font-bold mt-1">✓</span>
+                  <span className="text-accent font-bold mt-1">✓</span>
                   <span>{point}</span>
                 </li>
               ))}

--- a/app/products/[category]/page.tsx
+++ b/app/products/[category]/page.tsx
@@ -111,7 +111,7 @@ export default function CategoryPage() {
                   ? `/products/${category}/${sub.id}`
                   : `/products/${category}/${sub.id}/items`
               }
-              className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700 transition w-max"
+              className="bg-primary text-white px-6 py-3 rounded hover:bg-accent transition w-max"
             >
               ZIE MEER
             </Link>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -47,7 +47,7 @@ export default function ProductenPage() {
               {categories.map((cat) => (
                 <li key={cat.id}>
                   <Link href={`/products/${encodeURIComponent(cat.name.toLowerCase())}`}>
-                    <span className="text-lg font-medium text-gray-800 hover:text-blue-600 transition cursor-pointer">
+                    <span className="text-lg font-medium text-gray-800 hover:text-accent transition cursor-pointer">
                       {cat.name}
                     </span>
                   </Link>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,10 @@ module.exports = {
   ],
   theme: {
     extend: {
+      colors: {
+        primary: "#FE9247",
+        accent: "#FE0300",
+      },
       fontFamily: {
         roboto: ["var(--font-roboto)", "sans-serif"],
       },


### PR DESCRIPTION
## Summary
- set `primary` and `accent` colors in Tailwind config
- update Hero gradient and accent color
- change Navbar background and hover styles
- apply new colors to admin pages and product listings

## Testing
- `npm install`
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686af4cb7d688325be46ecbd7a7f202f