### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -30,13 +30,13 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="bg-white shadow-sm border-b border-gray-200 z-50 relative font-roboto h-24">
-      <div className="w-full h-full flex items-center justify-between px-12 pl-32">
+    <nav className="bg-white shadow-sm border-b border-gray-200 z-50 relative font-roboto h-16 md:h-24">
+      <div className="max-w-screen-xl mx-auto w-full h-full flex flex-wrap md:flex-nowrap items-center justify-between px-4 md:px-12 lg:pl-32">
         <Link href="/" className="flex items-center">
           <img src="/logo.png" alt="Logo" className="h-14" />
         </Link>
 
-        <ul className="flex gap-12 items-center text-xl font-semibold tracking-wide">
+        <ul className="flex flex-wrap justify-center gap-4 sm:gap-8 md:gap-12 items-center text-sm sm:text-base md:text-xl font-semibold tracking-wide w-full md:w-auto md:justify-start">
           <li>
             <Link
               href="/our-projects"
@@ -82,7 +82,7 @@ export default function Navbar() {
           </li>
         </ul>
 
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-4 justify-center md:justify-end w-full md:w-auto mt-4 md:mt-0">
           <SearchBar />
 
           {/* ← new logout button */}
@@ -105,7 +105,7 @@ export default function Navbar() {
             setActiveCategory(null);
             setActiveSubcategory(null);
           }}
-          className="fixed top-24 left-1/2 -translate-x-1/2 w-screen bg-white shadow-2xl border-t z-40 text-center animate-fade-in"
+          className="fixed left-1/2 -translate-x-1/2 w-screen bg-white shadow-2xl border-t z-40 text-center animate-fade-in top-16 md:top-24"
         >
           <div className="w-full max-w-[1400px] mx-auto">
             {loading ? (

--- a/app/components/SearchBar.tsx
+++ b/app/components/SearchBar.tsx
@@ -74,7 +74,7 @@ export default function SearchBar() {
   };
 
   return (
-    <div className="relative w-64">
+    <div className="relative w-full sm:w-48 md:w-64">
       <input
         type="text"
         placeholder="🔍 Zoek producten..."

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="nl" className={roboto.variable}>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body className="font-roboto">
         <GlobalDataProvider>
           {children}


### PR DESCRIPTION
## Summary
- include mobile viewport meta tag in the layout
- make navbar responsive for small screens
- allow search bar to adapt width

## Testing
- `npm run lint` *(fails: various existing lint errors)*
- `npm run build` *(fails: eslint errors during build)*

------
https://chatgpt.com/codex/tasks/task_e_687407a603088325bb7a9b2711b0d2af